### PR TITLE
chore: update nwaku docker and compose docs

### DIFF
--- a/docs/guides/nodes-and-sdks.md
+++ b/docs/guides/nodes-and-sdks.md
@@ -45,4 +45,4 @@ Waku provides integrations tailored for mobile applications, enabling Waku to ru
 | JSON-RPC API | `JSON-RPC` API interface provided by `nwaku` and `go-waku` to interact with the Waku Network | COMING SOON |
 | [@waku/react](https://www.npmjs.com/package/@waku/react) | React components and UI adapters designed for seamless integration with `@waku/sdk` | COMING SOON |
 | [@waku/create-app](https://www.npmjs.com/package/@waku/create-app) | Starter kit to bootstrap your next `@waku/sdk` project from various example templates | [Bootstrap DApps Using @waku/create-app](/guides/js-waku/use-waku-create-app) |
-| [nwaku-compose](https://github.com/alrevuelta/nwaku-compose) | Pre-configured Docker Compose setup for running and monitoring a `nwaku` node using Prometheus and Grafana | [Run Nwaku with Docker Compose](/guides/nwaku/run-docker-compose) |
+| [nwaku-compose](https://github.com/waku-org/nwaku-compose) | Pre-configured Docker Compose setup for running and monitoring a `nwaku` node using Prometheus and Grafana | [Run Nwaku with Docker Compose](/guides/nwaku/run-docker-compose) |

--- a/docs/guides/nwaku/run-docker-compose.md
+++ b/docs/guides/nwaku/run-docker-compose.md
@@ -4,7 +4,7 @@ title: Run Nwaku with Docker Compose
 
 `nwaku-compose` is a ready-to-use Docker Compose setup that runs a nwaku node and monitors it with already configured [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/) instances.
 
-This guide provides detailed steps to build, configure, run, and monitor a `nwaku` node with [nwaku-compose](https://github.com/alrevuelta/nwaku-compose).
+This guide provides detailed steps to build, configure, run, and monitor a `nwaku` node with [nwaku-compose](https://github.com/waku-org/nwaku-compose).
 
 ## Prerequisites
 
@@ -15,20 +15,19 @@ This guide provides detailed steps to build, configure, run, and monitor a `nwak
 ## Clone the Repository
 
 ```bash
-git clone https://github.com/alrevuelta/nwaku-compose
+git clone https://github.com/waku-org/nwaku-compose
 cd nwaku-compose
 ```
 
 ## Configure the Setup
 
-Modify the `docker-compose.yml` file to customise your node's configuration, including the [Docker image](https://hub.docker.com/r/statusteam/nim-waku/tags) and [nwaku arguments](/guides/reference/node-config-options).
+Modify the `run_node.sh` file to customise your [node's configuration](/guides/reference/node-config-options) and `docker-compose.yml` to specify particular [Docker image](https://hub.docker.com/r/statusteam/nim-waku/tags) tag.
 
 ## Run Docker Compose
 
-Export your public IP (`MY_EXT_IP`) and run `nwaku-compose`:
+Spin up the containers using `docker-compose`:
 
 ```bash
-export MY_EXT_IP=$(dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | awk -F'"' '{ print $2}')
 docker-compose up -d
 ```
 

--- a/docs/guides/nwaku/run-docker.md
+++ b/docs/guides/nwaku/run-docker.md
@@ -12,12 +12,6 @@ Ensure [Docker](https://www.docker.com/) is installed on your system using the a
 
 The Nwaku Docker images are available on the Docker Hub public registry under the [statusteam/nim-waku](https://hub.docker.com/r/statusteam/nim-waku) repository. Please visit [statusteam/nim-waku/tags](https://hub.docker.com/r/statusteam/nim-waku/tags) for images of specific releases.
 
-Pull the latest docker image:
-
-```bash
-docker pull statusteam/nim-waku
-```
-
 You can also build the Docker image locally:
 
 ```bash
@@ -44,7 +38,7 @@ docker run [OPTIONS] [IMAGE] [ARG...]
 Run `nwaku` using the most typical configuration:
 
 ```bash
-docker run -i -t -p 60000:60000 -p 9000:9000/udp statusteam/nim-waku \
+docker run -i -t -p 60000:60000 -p 9000:9000/udp statusteam/nim-waku:v0.18.0 \
   --dns-discovery=true \
   --dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
   --discv5-discovery=true \

--- a/docs/guides/nwaku/run-docker.md
+++ b/docs/guides/nwaku/run-docker.md
@@ -38,7 +38,7 @@ docker run [OPTIONS] [IMAGE] [ARG...]
 Run `nwaku` using the most typical configuration:
 
 ```bash
-docker run -i -t -p 60000:60000 -p 9000:9000/udp statusteam/nim-waku:v0.18.0 \
+docker run -i -t -p 60000:60000 -p 9000:9000/udp statusteam/nim-waku:v0.19.0 \
   --dns-discovery=true \
   --dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
   --discv5-discovery=true \


### PR DESCRIPTION
This PR:

- removes references to `alreavuelta/nwaku-compose` in favour of `waku-org/nwaku-compose`
- removes reference to `latest` image tag as that is not currently updated in registry (will add it back when fixed)
-  updates the nwaku-compose guide with how to configure the options
- pins the Docker guide `docker run` command to a last releast tag