### PR TITLE
add js-waku encryption guide

### DIFF
--- a/docs/guides/js-waku/index.md
+++ b/docs/guides/js-waku/index.md
@@ -85,7 +85,7 @@ Have a look at the quick start guide and comprehensive tutorials to learn how to
 | - | - |
 | [Send and Receive Messages Using Light Push and Filter](/guides/js-waku/light-send-receive) | Learn how to send and receive messages on light nodes using the [Light Push](/learn/concepts/protocols#light-push) and [Filter](/learn/concepts/protocols#filter) protocols |
 | [Retrieve Messages Using Store Protocol](/guides/js-waku/store-retrieve-messages) | Learn how to retrieve and filter historical messages on light nodes using the [Store protocol](/learn/concepts/protocols#store) |
-| [Encrypt and Decrypt Your Waku Messages](/guides/js-waku/message-encryption) | Learn how to use the [@waku/message-encryption](https://www.npmjs.com/package/@waku/message-encryption) package to encrypt and decrypt your messages |
+| [Encrypt, Decrypt, and Sign Your Messages](/guides/js-waku/message-encryption) | Learn how to use the [@waku/message-encryption](https://www.npmjs.com/package/@waku/message-encryption) package to encrypt, decrypt, and sign your messages |
 | [Build React DApps Using @waku/react](/guides/js-waku/use-waku-react) | Learn how to use the [@waku/react](https://www.npmjs.com/package/@waku/react) package seamlessly integrate `@waku/sdk` into a React application |
 | [Scaffold DApps Using @waku/create-app](/guides/js-waku/use-waku-create-app) | Learn how to use the [@waku/create-app](https://www.npmjs.com/package/@waku/create-app) package to bootstrap your next `@waku/sdk` project from various example templates |
 | [Bootstrap Nodes and Discover Peers](/guides/js-waku/configure-discovery) | Learn how to bootstrap your node using [Static Peers](/learn/concepts/static-peers) and discover peers using [DNS Discovery](/learn/concepts/dns-discovery) |

--- a/docs/guides/js-waku/index.md
+++ b/docs/guides/js-waku/index.md
@@ -85,6 +85,7 @@ Have a look at the quick start guide and comprehensive tutorials to learn how to
 | - | - |
 | [Send and Receive Messages Using Light Push and Filter](/guides/js-waku/light-send-receive) | Learn how to send and receive messages on light nodes using the [Light Push](/learn/concepts/protocols#light-push) and [Filter](/learn/concepts/protocols#filter) protocols |
 | [Retrieve Messages Using Store Protocol](/guides/js-waku/store-retrieve-messages) | Learn how to retrieve and filter historical messages on light nodes using the [Store protocol](/learn/concepts/protocols#store) |
+| [Encrypt and Decrypt Your Waku Messages](/guides/js-waku/message-encryption) | Learn how to use the [@waku/message-encryption](https://www.npmjs.com/package/@waku/message-encryption) package to encrypt and decrypt your messages |
 | [Build React DApps Using @waku/react](/guides/js-waku/use-waku-react) | Learn how to use the [@waku/react](https://www.npmjs.com/package/@waku/react) package seamlessly integrate `@waku/sdk` into a React application |
 | [Scaffold DApps Using @waku/create-app](/guides/js-waku/use-waku-create-app) | Learn how to use the [@waku/create-app](https://www.npmjs.com/package/@waku/create-app) package to bootstrap your next `@waku/sdk` project from various example templates |
 | [Bootstrap Nodes and Discover Peers](/guides/js-waku/configure-discovery) | Learn how to bootstrap your node using [Static Peers](/learn/concepts/static-peers) and discover peers using [DNS Discovery](/learn/concepts/dns-discovery) |

--- a/docs/guides/js-waku/light-send-receive.md
+++ b/docs/guides/js-waku/light-send-receive.md
@@ -128,7 +128,7 @@ const callback = (wakuMessage) => {
     console.log(messageObj);
 };
 
-// Create a filter subscription
+// Create a Filter subscription
 const subscription = await node.filter.createSubscription();
 
 // Subscribe to content topics and process new messages

--- a/docs/guides/js-waku/manage-filter.md
+++ b/docs/guides/js-waku/manage-filter.md
@@ -3,7 +3,7 @@ title: Manage Your Filter Subscriptions
 hide_table_of_contents: true
 ---
 
-This guide provides detailed steps to manage [Filter](/learn/concepts/protocols#filter) subscriptions and handle node disconnections in your application. Have a look at the [Filter guide](/guides/js-waku/light-send-receive) for receiving messages with the `Light Push` and `Filter` protocol.
+This guide provides detailed steps to manage [Filter](/learn/concepts/protocols#filter) subscriptions and handle node disconnections in your application. Have a look at the [Send and Receive Messages Using Light Push and Filter](/guides/js-waku/light-send-receive) guide for using the `Light Push` and `Filter` protocols.
 
 ## Overview
 

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -1,0 +1,127 @@
+---
+title: Encrypt and Decrypt Your Waku Messages
+hide_table_of_contents: true
+---
+
+This guide provides detailed steps to use the [@waku/message-encryption](https://www.npmjs.com/package/@waku/message-encryption) package to encrypt and decrypt your messages using [Waku message payload encryption](/learn/glossary#waku-message-payload-encryption) methods.
+
+:::info
+Waku lacks protocol-level message encryption because it does not know the communication parties. This design choice enhances Waku's encryption flexibility, encouraging developers to freely use custom protocols or [Waku message payload encryption](/learn/glossary#waku-message-payload-encryption) methods.
+:::
+
+## Installation
+
+Install the `@waku/message-encryption` package using your preferred package manager:
+
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
+<Tabs groupId="package-manager">
+<TabItem value="npm" label="NPM">
+
+```shell
+npm install @waku/message-encryption
+```
+
+</TabItem>
+<TabItem value="yarn" label="Yarn">
+
+```shell
+yarn add @waku/message-encryption
+```
+
+</TabItem>
+</Tabs>
+
+## Symmetric encryption
+
+Symmetric encryption uses a single, shared key for message encryption and decryption. Use the `generateSymmetricKey()` function to generate a random symmetric key:
+
+```js
+import { generateSymmetricKey } from "@waku/message-encryption";
+
+// Generate a random symmetric key
+const symKey = generateSymmetricKey();
+```
+
+To send encrypted messages, create a symmetric message `encoder` and send the message as usual:
+
+```js
+import { createEncoder } from "@waku/message-encryption/symmetric";
+
+// Create a symmetric message encoder
+const encoder = createEncoder({
+	contentTopic: contentTopic, // message content topic
+	symKey: symKey, // symmetric key for encrypting messages
+});
+
+// Send the message using Light Push
+await node.lightPush.send(encoder, { payload });
+```
+
+To decrypt the messages you receive, create a symmetric message `decoder` and process the messages as usual:
+
+```js
+import { createDecoder } from "@waku/message-encryption/symmetric";
+
+// Create a symmetric message decoder
+const decoder = createDecoder(contentTopic, symKey);
+
+// Receive messages from a Filter subscription
+const subscription = await node.filter.createSubscription();
+await subscription.subscribe([decoder], callback);
+
+// Retrieve messages from Store peers
+await node.store.queryWithOrderedCallback([decoder], callback);
+```
+
+## ECIES encryption
+
+ECIES encryption uses a public key for encryption and a private key for decryption. Use the `generatePrivateKey()` function to generate a random private key:
+
+```js
+import { generatePrivateKey, getPublicKey } from "@waku/message-encryption";
+
+// Generate a random private key, keep secure
+const privateKey = generatePrivateKey();
+
+// Generate a public key from the private key, provide to the sender
+const publicKey = getPublicKey(privateKey);
+```
+
+To send encrypted messages, create an ECIES message `encoder` with the public key and send the message as usual:
+
+```js
+import { createEncoder } from "@waku/message-encryption/ecies";
+
+// Create an ECIES message encoder
+const encoder = createEncoder({
+	contentTopic: contentTopic, // message content topic
+	publicKey: publicKey, // ECIES public key for encrypting messages
+});
+
+// Send the message using Light Push
+await node.lightPush.send(encoder, { payload });
+```
+
+To decrypt the messages you receive, create an ECIES message `decoder` with the private key and process the messages as usual:
+
+```js
+import { createDecoder } from "@waku/message-encryption/ecies";
+
+// Create an ECIES message decoder
+const decoder = createDecoder(contentTopic, privateKey);
+
+// Receive messages from a Filter subscription
+const subscription = await node.filter.createSubscription();
+await subscription.subscribe([decoder], callback);
+
+// Retrieve messages from Store peers
+await node.store.queryWithOrderedCallback([decoder], callback);
+```
+
+:::tip Congratulations!
+You have successfully encrypted and decrypted your messages using `symmetric` and `ECIES` encryption methods. Have a look at the [flush-notes](https://github.com/waku-org/js-waku-examples/tree/master/examples/flush-notes) example for a working demo.
+:::

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -1,9 +1,9 @@
 ---
-title: Encrypt and Decrypt Your Waku Messages
+title: Encrypt, Decrypt, and Sign Your Messages
 hide_table_of_contents: true
 ---
 
-This guide provides detailed steps to use the [@waku/message-encryption](https://www.npmjs.com/package/@waku/message-encryption) package to encrypt and decrypt your messages using [Waku message payload encryption](/learn/glossary#waku-message-payload-encryption) methods.
+This guide provides detailed steps to use the [@waku/message-encryption](https://www.npmjs.com/package/@waku/message-encryption) package to encrypt, decrypt, and sign your messages using [Waku message payload encryption](/learn/glossary#waku-message-payload-encryption) methods.
 
 :::info
 Waku lacks protocol-level message encryption because it does not know the communication parties. This design choice enhances Waku's encryption flexibility, encouraging developers to freely use custom protocols or [Waku message payload encryption](/learn/glossary#waku-message-payload-encryption) methods.
@@ -37,7 +37,7 @@ yarn add @waku/message-encryption
 
 ## Symmetric encryption
 
-Symmetric encryption uses a single, shared key for message encryption and decryption. Use the `generateSymmetricKey()` function to generate a random symmetric key:
+`Symmetric` encryption uses a single, shared key for message encryption and decryption. Use the `generateSymmetricKey()` function to generate a random symmetric key:
 
 ```js
 import { generateSymmetricKey } from "@waku/message-encryption";
@@ -46,7 +46,7 @@ import { generateSymmetricKey } from "@waku/message-encryption";
 const symKey = generateSymmetricKey();
 ```
 
-To send encrypted messages, create a symmetric message `encoder` and send the message as usual:
+To send encrypted messages, create a `Symmetric` message `encoder` and send the message as usual:
 
 ```js
 import { createEncoder } from "@waku/message-encryption/symmetric";
@@ -79,7 +79,7 @@ await node.store.queryWithOrderedCallback([decoder], callback);
 
 ## ECIES encryption
 
-ECIES encryption uses a public key for encryption and a private key for decryption. Use the `generatePrivateKey()` function to generate a random private key:
+`ECIES` encryption uses a public key for encryption and a private key for decryption. Use the `generatePrivateKey()` function to generate a random private key:
 
 ```js
 import { generatePrivateKey, getPublicKey } from "@waku/message-encryption";
@@ -91,7 +91,7 @@ const privateKey = generatePrivateKey();
 const publicKey = getPublicKey(privateKey);
 ```
 
-To send encrypted messages, create an ECIES message `encoder` with the public key and send the message as usual:
+To send encrypted messages, create an `ECIES` message `encoder` with the public key and send the message as usual:
 
 ```js
 import { createEncoder } from "@waku/message-encryption/ecies";
@@ -106,7 +106,7 @@ const encoder = createEncoder({
 await node.lightPush.send(encoder, { payload });
 ```
 
-To decrypt the messages you receive, create an ECIES message `decoder` with the private key and process the messages as usual:
+To decrypt the messages you receive, create an `ECIES` message `decoder` with the private key and process the messages as usual:
 
 ```js
 import { createDecoder } from "@waku/message-encryption/ecies";
@@ -122,6 +122,35 @@ await subscription.subscribe([decoder], callback);
 await node.store.queryWithOrderedCallback([decoder], callback);
 ```
 
+## Signing encrypted messages
+
+Message signing helps in proving the authenticity of received messages. By attaching a signature to a message, you can verify its origin and integrity with absolute certainty.
+
+The `sigPrivKey` option allows the `Symmetric` and `ECIES` message `encoders` to sign the message before encryption using an `ECDSA` private key:
+
+```js
+import { generatePrivateKey } from "@waku/message-encryption";
+import { createEncoder as createSymmetricEncoder } from "@waku/message-encryption/symmetric";
+import { createEncoder as createECIESEncoder } from "@waku/message-encryption/ecies";
+
+// Generate a random private key for signing messages
+const sigPrivKey = generatePrivateKey();
+
+// Create a symmetric encoder that signs messages
+const symmetricEncoder = createSymmetricEncoder({
+    contentTopic: contentTopic, // message content topic
+    symKey: symKey, // symmetric key for encrypting messages
+	sigPrivKey: sigPrivKey, // private key for signing messages before encryption
+});
+
+// Create an ECIES encoder that signs messages
+const ECIESEncoder = createECIESEncoder({
+    contentTopic: contentTopic, // message content topic
+    publicKey: publicKey, // ECIES public key for encrypting messages
+	sigPrivKey: sigPrivKey, // private key for signing messages before encryption
+});
+```
+
 :::tip Congratulations!
-You have successfully encrypted and decrypted your messages using `symmetric` and `ECIES` encryption methods. Have a look at the [flush-notes](https://github.com/waku-org/js-waku-examples/tree/master/examples/flush-notes) example for a working demo.
+You have successfully encrypted, decrypted, and signed your messages using `symmetric` and `ECIES` encryption methods. Have a look at the [flush-notes](https://github.com/waku-org/js-waku-examples/tree/master/examples/flush-notes) example for a working demo.
 :::

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -48,7 +48,7 @@ const symKey = generateSymmetricKey();
 
 To send encrypted messages, create a `Symmetric` message `encoder` and send the message as usual:
 
-```js
+```js title="Sender client"
 import { createEncoder } from "@waku/message-encryption/symmetric";
 
 // Create a symmetric message encoder
@@ -63,7 +63,7 @@ await node.lightPush.send(encoder, { payload });
 
 To decrypt the messages you receive, create a symmetric message `decoder` and process the messages as usual:
 
-```js
+```js title="Receiver client"
 import { createDecoder } from "@waku/message-encryption/symmetric";
 
 // Create a symmetric message decoder
@@ -97,7 +97,7 @@ const publicKey = getPublicKey(privateKey);
 
 To send encrypted messages, create an `ECIES` message `encoder` with the public key and send the message as usual:
 
-```js
+```js title="Sender client"
 import { createEncoder } from "@waku/message-encryption/ecies";
 
 // Create an ECIES message encoder
@@ -112,7 +112,7 @@ await node.lightPush.send(encoder, { payload });
 
 To decrypt the messages you receive, create an `ECIES` message `decoder` with the private key and process the messages as usual:
 
-```js
+```js title="Receiver client"
 import { createDecoder } from "@waku/message-encryption/ecies";
 
 // Create an ECIES message decoder
@@ -140,7 +140,7 @@ Signing messages is only possible when encrypted, but if your application does n
 
 The `sigPrivKey` option allows the `Symmetric` and `ECIES` message `encoders` to sign the message before encryption using an `ECDSA` private key:
 
-```js title="Alice (Sender) Client"
+```js title="Alice (sender) client"
 import { generatePrivateKey, getPublicKey } from "@waku/message-encryption";
 import { createEncoder as createSymmetricEncoder } from "@waku/message-encryption/symmetric";
 import { createEncoder as createECIESEncoder } from "@waku/message-encryption/ecies";
@@ -175,7 +175,7 @@ await node.lightPush.send(ECIESEncoder, { payload });
 
 You can extract the `signature` and its public key (`signaturePublicKey`) from the [DecodedMessage](https://js.waku.org/classes/_waku_message_encryption.DecodedMessage.html) and compare it with the expected public key to verify the message origin:
 
-```js title="Bob (Receiver) Client"
+```js title="Bob (receiver) client"
 import { generatePrivateKey } from "@waku/message-encryption";
 import { createEncoder } from "@waku/message-encryption/symmetric";
 import { equals } from "uint8arrays/equals";
@@ -209,11 +209,11 @@ const callback = (wakuMessage) => {
 await subscription.subscribe([encoder], callback);
 ```
 
-## Restoring encryption keys
+## Storing encryption keys
 
 We used randomly generated keys for encryption and message signing in the provided examples, but real-world applications require consistent keys among clients. Have a look at the [Key Pair Handling](https://github.com/waku-org/js-waku-examples/tree/master/examples/eth-pm/src/key_pair_handling) example, which demonstrates the secure storage and retrieval of key information from local storage using [Subtle Crypto](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto).
 
-You can also use the [@waku/utils](https://www.npmjs.com/package/@waku/utils) package to convert keys into hexadecimal format:
+You can also use the [@waku/utils](https://www.npmjs.com/package/@waku/utils) package to store keys in hexadecimal format:
 
 ```js
 import { bytesToHex, hexToBytes } from "@waku/utils/bytes";
@@ -222,7 +222,7 @@ import { bytesToHex, hexToBytes } from "@waku/utils/bytes";
 const symKey = generateSymmetricKey();
 const privateKey = generatePrivateKey();
 
-// Convert the keys to hexadecimal format
+// Store the keys in hexadecimal format
 const symKeyHex = bytesToHex(symKey);
 const privateKeyHex = bytesToHex(privateKey);
 

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -209,9 +209,9 @@ await subscription.subscribe([encoder], callback);
 
 ## Storing encryption keys
 
-We used randomly generated keys for encryption and message signing in the provided examples, but real-world applications require consistent keys among clients. Have a look at the [Key Pair Handling](https://github.com/waku-org/js-waku-examples/tree/master/examples/eth-pm/src/key_pair_handling) example, which demonstrates the secure storage and retrieval of key information from local storage using [Subtle Crypto](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto).
+We used randomly generated keys for encryption and message signing in the provided examples, but real-world applications require consistent keys among client restarts. Have a look at the [Key Pair Handling](https://github.com/waku-org/js-waku-examples/tree/master/examples/eth-pm/src/key_pair_handling) example, which demonstrates the secure storage and retrieval of key information from local storage using [Subtle Crypto](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto).
 
-You can also use the [@waku/utils](https://www.npmjs.com/package/@waku/utils) package to store keys in hexadecimal format:
+If you need a simple way to store your keys in hexadecimal format across your application, you can use the [@waku/utils](https://www.npmjs.com/package/@waku/utils) package:
 
 ```js
 import { bytesToHex, hexToBytes } from "@waku/utils/bytes";

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -149,6 +149,44 @@ const ECIESEncoder = createECIESEncoder({
     publicKey: publicKey, // ECIES public key for encrypting messages
 	sigPrivKey: sigPrivKey, // private key for signing messages before encryption
 });
+
+// Send and receive your messages as usual with Light Push and Filter
+await node.lightPush.send(symmetricEncoder, { payload });
+await subscription.subscribe([symmetricEncoder], callback);
+
+await node.lightPush.send(ECIESEncoder, { payload });
+await subscription.subscribe([ECIESEncoder], callback);
+```
+
+You can extract the `signature` and its public key (`signaturePublicKey`) from the [DecodedMessage](https://js.waku.org/classes/_waku_message_encryption.DecodedMessage.html) and compare it with the expected public key to verify the message:
+
+```js
+// Generate a random private key for signing messages
+const sigPrivKey = generatePrivateKey();
+
+// Generate a public key from the private key for verifying signatures
+const sigPubKey = getPublicKey(sigPrivKey);
+
+// Create an encoder that signs messages
+const encoder = createEncoder({
+    contentTopic: contentTopic,
+    symKey: symKey,
+	sigPrivKey: sigPrivKey,
+});
+
+// Modify the callback function to verify message signature
+const callback = (wakuMessage) => {
+	// Extract the message signature and public key of the signature
+	const signature = wakuMessage.signature;
+	const signaturePublicKey = wakuMessage.signaturePublicKey;
+
+	// Compare the public key of the message signature with the sender's own
+	if (JSON.stringify(signaturePublicKey) === JSON.stringify(sigPubKey)) {
+		console.log("This message was correctly signed");
+	} else {
+		console.log("This message has an incorrect signature");
+	}
+};
 ```
 
 :::tip Congratulations!

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -11,7 +11,7 @@ Waku uses libp2p noise encryption for node-to-node connections. However, no defa
 
 ## Installation
 
-Install the `@waku/message-encryption` package using your preferred package manager:
+Install the required packages for integrating `@waku/message-encryption` using your preferred package manager:
 
 ```mdx-code-block
 import Tabs from '@theme/Tabs';
@@ -22,14 +22,14 @@ import TabItem from '@theme/TabItem';
 <TabItem value="npm" label="NPM">
 
 ```shell
-npm install @waku/message-encryption @waku/utils
+npm install @waku/message-encryption @waku/utils uint8arrays
 ```
 
 </TabItem>
 <TabItem value="yarn" label="Yarn">
 
 ```shell
-yarn add @waku/message-encryption @waku/utils
+yarn add @waku/message-encryption @waku/utils uint8arrays
 ```
 
 </TabItem>
@@ -174,6 +174,8 @@ await node.lightPush.send(ECIESEncoder, { payload });
 You can extract the `signature` and its public key (`signaturePublicKey`) from the [DecodedMessage](https://js.waku.org/classes/_waku_message_encryption.DecodedMessage.html) and compare it with the expected public key to verify the message origin:
 
 ```js
+import { equals } from "uint8arrays/equals";
+
 // Generate a random private key for signing messages
 const sigPrivKey = generatePrivateKey();
 
@@ -194,7 +196,7 @@ const callback = (wakuMessage) => {
 	const signaturePublicKey = wakuMessage.signaturePublicKey;
 
 	// Compare the public key of the message signature with the sender's own
-	if (JSON.stringify(signaturePublicKey) === JSON.stringify(sigPubKey)) {
+	if (equals(signaturePublicKey, sigPubKey)) {
 		console.log("This message was correctly signed");
 	} else {
 		console.log("This message has an incorrect signature");

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -171,11 +171,15 @@ await subscription.subscribe([ECIESEncoder], callback);
 await node.lightPush.send(ECIESEncoder, { payload });
 ```
 
-You can extract the `signature` and its public key (`signaturePublicKey`) from the [DecodedMessage](https://js.waku.org/classes/_waku_message_encryption.DecodedMessage.html) and compare it with the expected public key or use the `verifySignature()` function to verify the message origin:
+You can extract the `signature` and its public key (`signaturePublicKey`) from the [DecodedMessage](https://js.waku.org/classes/_waku_message_encryption.DecodedMessage.html) and compare it with the expected public key to verify the message origin:
+
+<!-- or use the `verifySignature()` function -->
+<!-- if (wakuMessage.verifySignature(alicePublicKey)) { -->
 
 ```js title="Bob (receiver) client"
 import { generatePrivateKey } from "@waku/message-encryption";
 import { createEncoder } from "@waku/message-encryption/symmetric";
+import { equals } from "uint8arrays/equals";
 
 // Generate a random private key for signing messages
 // For this example, we'll call the receiver of the message Bob
@@ -197,7 +201,7 @@ const callback = (wakuMessage) => {
 
 	// Verify the message was actually signed and sent by Alice
 	// Alice's public key can be gotten from broadcasting or out-of-band methods
-	if (wakuMessage.verifySignature(alicePublicKey)) {
+	if (equals(signaturePublicKey, alicePublicKey)) {
 		console.log("This message was signed by Alice");
 	} else {
 		console.log("This message was NOT signed by Alice");
@@ -230,5 +234,7 @@ const restoredPrivateKey = hexToBytes(privateKeyHex);
 ```
 
 :::tip Congratulations!
-You have successfully encrypted, decrypted, and signed your messages using `Symmetric` and `ECIES` encryption methods. Have a look at the [flush-notes](https://github.com/waku-org/js-waku-examples/tree/master/examples/flush-notes) and [eth-pm](https://github.com/waku-org/js-waku-examples/tree/master/examples/eth-pm) examples for working demos.
+You have successfully encrypted, decrypted, and signed your messages using `Symmetric` and `ECIES` encryption methods. Have a look at the [eth-pm](https://github.com/waku-org/js-waku-examples/tree/master/examples/eth-pm) example for a working demo.
 :::
+
+<!-- [flush-notes](https://github.com/waku-org/js-waku-examples/tree/master/examples/flush-notes) and -->

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -211,28 +211,26 @@ await subscription.subscribe([encoder], callback);
 
 ## Restoring encryption keys
 
-We used randomly generated keys for encryption and message signing in the provided examples, but real-world applications require consistent keys among clients. You can use the [@waku/utils](https://www.npmjs.com/package/@waku/utils) package to convert keys into a hexadecimal format for uniformity:
+We used randomly generated keys for encryption and message signing in the provided examples, but real-world applications require consistent keys among clients. Have a look at the [Key Pair Handling](https://github.com/waku-org/js-waku-examples/tree/master/examples/eth-pm/src/key_pair_handling) example, which demonstrates the secure storage and retrieval of key information from local storage using [Subtle Crypto](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto).
+
+You can also use the [@waku/utils](https://www.npmjs.com/package/@waku/utils) package to convert keys into hexadecimal format:
 
 ```js
 import { bytesToHex, hexToBytes } from "@waku/utils/bytes";
-import { generateSymmetricKey, generatePrivateKey } from "@waku/message-encryption";
 
 // Generate random symmetric and private keys
 const symKey = generateSymmetricKey();
 const privateKey = generatePrivateKey();
-console.log(symKey, privateKey);
 
 // Convert the keys to hexadecimal format
 const symKeyHex = bytesToHex(symKey);
 const privateKeyHex = bytesToHex(privateKey);
-console.log(symKeyHex, privateKeyHex);
 
 // Restore the keys from hexadecimal format
 const restoredSymKey = hexToBytes(symKeyHex);
 const restoredPrivateKey = hexToBytes(privateKeyHex);
-console.log(restoredSymKey, restoredPrivateKey);
 ```
 
 :::tip Congratulations!
-You have successfully encrypted, decrypted, and signed your messages using `symmetric` and `ECIES` encryption methods. Have a look at the [flush-notes](https://github.com/waku-org/js-waku-examples/tree/master/examples/flush-notes) example for a working demo.
+You have successfully encrypted, decrypted, and signed your messages using `Symmetric` and `ECIES` encryption methods. Have a look at the [flush-notes](https://github.com/waku-org/js-waku-examples/tree/master/examples/flush-notes) and [eth-pm](https://github.com/waku-org/js-waku-examples/tree/master/examples/eth-pm) examples for working demos.
 :::

--- a/docs/guides/js-waku/message-encryption.md
+++ b/docs/guides/js-waku/message-encryption.md
@@ -22,14 +22,14 @@ import TabItem from '@theme/TabItem';
 <TabItem value="npm" label="NPM">
 
 ```shell
-npm install @waku/message-encryption
+npm install @waku/message-encryption @waku/utils
 ```
 
 </TabItem>
 <TabItem value="yarn" label="Yarn">
 
 ```shell
-yarn add @waku/message-encryption
+yarn add @waku/message-encryption @waku/utils
 ```
 
 </TabItem>
@@ -138,24 +138,24 @@ const sigPrivKey = generatePrivateKey();
 
 // Create a symmetric encoder that signs messages
 const symmetricEncoder = createSymmetricEncoder({
-    contentTopic: contentTopic, // message content topic
-    symKey: symKey, // symmetric key for encrypting messages
+	contentTopic: contentTopic, // message content topic
+	symKey: symKey, // symmetric key for encrypting messages
 	sigPrivKey: sigPrivKey, // private key for signing messages before encryption
 });
 
 // Create an ECIES encoder that signs messages
 const ECIESEncoder = createECIESEncoder({
-    contentTopic: contentTopic, // message content topic
-    publicKey: publicKey, // ECIES public key for encrypting messages
+	contentTopic: contentTopic, // message content topic
+	publicKey: publicKey, // ECIES public key for encrypting messages
 	sigPrivKey: sigPrivKey, // private key for signing messages before encryption
 });
 
 // Send and receive your messages as usual with Light Push and Filter
-await node.lightPush.send(symmetricEncoder, { payload });
 await subscription.subscribe([symmetricEncoder], callback);
+await node.lightPush.send(symmetricEncoder, { payload });
 
-await node.lightPush.send(ECIESEncoder, { payload });
 await subscription.subscribe([ECIESEncoder], callback);
+await node.lightPush.send(ECIESEncoder, { payload });
 ```
 
 You can extract the `signature` and its public key (`signaturePublicKey`) from the [DecodedMessage](https://js.waku.org/classes/_waku_message_encryption.DecodedMessage.html) and compare it with the expected public key to verify the message:
@@ -169,8 +169,8 @@ const sigPubKey = getPublicKey(sigPrivKey);
 
 // Create an encoder that signs messages
 const encoder = createEncoder({
-    contentTopic: contentTopic,
-    symKey: symKey,
+	contentTopic: contentTopic,
+	symKey: symKey,
 	sigPrivKey: sigPrivKey,
 });
 
@@ -187,6 +187,30 @@ const callback = (wakuMessage) => {
 		console.log("This message has an incorrect signature");
 	}
 };
+```
+
+## Restoring encryption keys
+
+We used randomly generated keys for encryption and message signing in the provided examples, but real-world applications require consistent keys among clients. You can use the [@waku/utils](https://www.npmjs.com/package/@waku/utils) package to convert keys into a hexadecimal format for uniformity:
+
+```js
+import { bytesToHex, hexToBytes } from "@waku/utils/bytes";
+import { generateSymmetricKey, generatePrivateKey } from "@waku/message-encryption";
+
+// Generate random symmetric and private keys
+const symKey = generateSymmetricKey();
+const privateKey = generatePrivateKey();
+console.log(symKey, privateKey);
+
+// Convert the keys to hexadecimal format
+const symKeyHex = bytesToHex(symKey);
+const privateKeyHex = bytesToHex(privateKey);
+console.log(symKeyHex, privateKeyHex);
+
+// Restore the keys from hexadecimal format
+const restoredSymKey = hexToBytes(symKeyHex);
+const restoredPrivateKey = hexToBytes(privateKeyHex);
+console.log(restoredSymKey, restoredPrivateKey);
 ```
 
 :::tip Congratulations!

--- a/docs/guides/js-waku/use-waku-react.md
+++ b/docs/guides/js-waku/use-waku-react.md
@@ -31,7 +31,7 @@ yarn create vite [PROJECT DIRECTORY] --template react
 </TabItem>
 </Tabs>
 
-Next, install the required libraries for integrating `@waku/sdk` using your preferred package manager:
+Next, install the required packages for integrating `@waku/sdk` using your preferred package manager:
 
 <Tabs groupId="package-manager">
 <TabItem value="npm" label="NPM">

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -63,6 +63,10 @@ A node is a device or client that implements Waku [protocols](#protocol) and lev
 
 A node key is a [Secp256k1](https://en.bitcoin.it/wiki/Secp256k1) (64-char hex string) private key for generating the [PeerID](#peer-id), [listening](#transport) addresses, and [discovery](#peer-discovery) addresses of a Waku node.
 
+### Out-of-band
+
+Out-of-band refers to exchanging information through a separate, secure channel distinct from the main communication method to enhance security.
+
 ### Payload
 
 The payload field in a [Waku Message](#waku-message) contains the application data, serving as the business logic message transmitted between clients over Waku. Applications can encrypt the payload or employ encryption methods specified in [Waku Message Payload Encryption](#waku-message-payload-encryption).

--- a/docs/learn/waku-network.md
+++ b/docs/learn/waku-network.md
@@ -3,10 +3,6 @@ title: The Waku Network
 hide_table_of_contents: true
 ---
 
-:::info
-The public Waku Network replaces the previous experimental shared routing layer based on a default pubsub topic (`/waku/2/default-waku/proto`). If your project currently uses this or any other shared pubsub topics, we encourage you to migrate to the public Waku Network with built-in DoS protection, with built-in DoS protection, scalability and reasonable bandwidth usage.
-:::
-
 The Waku Network is a shared p2p messaging network that is open-access, useful for generalized messaging, privacy-preserving, scalable and accessible even to resource-restricted devices. Some of the most prominent features include:
 
 1. DoS/spam protection with privacy-preserving [Rate-Limiting Nullifiers](https://rfc.vac.dev/spec/64/#rln-rate-limiting).
@@ -15,6 +11,10 @@ The Waku Network is a shared p2p messaging network that is open-access, useful f
 4. [Services](https://rfc.vac.dev/spec/64/#default-services) for resource-restricted nodes, including historical message storage and retrieval, filtering, etc.
 
 If you want to learn more about the Waku Network, the [WAKU2-NETWORK RFC](https://rfc.vac.dev/spec/64/) provides an in-depth look under the hood.
+
+:::info
+The public Waku Network replaces the previous experimental shared routing layer based on a default pubsub topic (`/waku/2/default-waku/proto`). If your project currently uses this or any other shared pubsub topics, we encourage you to migrate to the public Waku Network with built-in DoS protection, with built-in DoS protection, scalability, and reasonable bandwidth usage.
+:::
 
 ## Why join the Waku network?
 

--- a/docs/learn/waku-network.md
+++ b/docs/learn/waku-network.md
@@ -13,7 +13,7 @@ The Waku Network is a shared p2p messaging network that is open-access, useful f
 If you want to learn more about the Waku Network, the [WAKU2-NETWORK RFC](https://rfc.vac.dev/spec/64/) provides an in-depth look under the hood.
 
 :::info
-The public Waku Network replaces the previous experimental shared routing layer based on a default pubsub topic (`/waku/2/default-waku/proto`). If your project currently uses this or any other shared pubsub topics, we encourage you to migrate to the public Waku Network with built-in DoS protection, with built-in DoS protection, scalability, and reasonable bandwidth usage.
+The public Waku Network replaces the previous experimental shared routing layer based on a default pubsub topic (`/waku/2/default-waku/proto`). If your project currently uses this or any other shared pubsub topics, we encourage you to migrate to the public Waku Network with built-in DoS protection, scalability, and reasonable bandwidth usage.
 :::
 
 ## Why join the Waku network?

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,6 +150,10 @@ const config = {
               href: "https://rfc.vac.dev/",
               label: "Vac RFCs",
             },
+            {
+              href: "https://github.com/waku-org/awesome-waku/",
+              label: "Awesome Waku",
+            },
           ],
         },
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -35,6 +35,7 @@ const sidebars = {
 			items: [
 				"guides/js-waku/light-send-receive",
 				"guides/js-waku/store-retrieve-messages",
+				"guides/js-waku/message-encryption",
 				"guides/js-waku/use-waku-react",
 				"guides/js-waku/use-waku-create-app",
 				"guides/js-waku/configure-discovery",


### PR DESCRIPTION
Tackles some of the tasks in https://github.com/waku-org/docs.waku.org/issues/125

preview: https://docs-waku-org-git-js-encryption-acidinfo.vercel.app/guides/js-waku/message-encryption

pending:

- [ ] merging https://github.com/waku-org/js-waku-examples/pull/286
- [ ] release of @waku/sdk with `verifySignature()`