### PR TITLE
Use certbot certonly

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -75,6 +75,7 @@
     "sepolia",
     "faucet",
     "concat",
+    "certonly",
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/docs/guides/nwaku/configure-nwaku.md
+++ b/docs/guides/nwaku/configure-nwaku.md
@@ -151,7 +151,7 @@ Consider a `nwaku` node that enabled Secure WebSocket (encrypted) using its key 
 You can use [Let's Encrypt](https://letsencrypt.org/) or [Certbot](https://certbot.eff.org/) to generate a valid certificate for your `nwaku` node:
 
 ```shell
-sudo letsencrypt -d <your.domain.name>
+sudo certbot certonly -d <your.domain.name>
 ```
 :::
 


### PR DESCRIPTION
letsencrypt only work if a webserver is installed. We can assume if someone installed a webserver, they know what they are doing.

Someone just using the docker-compose needs certbot