### PR TITLE
fix: testnet key naming and add timestamp to sample message send

### DIFF
--- a/docs/guides/nwaku/run-docker-compose.md
+++ b/docs/guides/nwaku/run-docker-compose.md
@@ -32,7 +32,7 @@ Modify the `run_node.sh` file to customise your [node's configuration](/guides/n
 
 ```shell
 export ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/[INFURA API KEY]
-export ETH_TESTNET_KEY=[INFURA API KEY]
+export ETH_TESTNET_KEY=[TESTNET PRIVATE KEY]
 export KEYSTORE_PASSWORD=[RLN MEMBERSHIP PASSWORD]
 ```
 
@@ -85,7 +85,8 @@ curl --location 'http://127.0.0.1:8645/relay/v1/auto/messages' \
 --header 'Content-Type: application/json' \
 --data '{
     "payload": "'$(echo -n "Hello Waku Network - from Anonymous User" | base64)'",
-    "contentTopic": "/my-app/2/chatroom-1/proto"
+    "contentTopic": "/my-app/2/chatroom-1/proto",
+    "timestamp":'$(date +%s)'
 }'
 ```
 


### PR DESCRIPTION
The naming was confusing to hackers wanting to run a node, changed it to reflect the private key.