### PR TITLE
extending faq adding how to run a node point

### DIFF
--- a/docs/learn/faq.md
+++ b/docs/learn/faq.md
@@ -35,7 +35,7 @@ import { AccordionItem } from '@site/src/components/mdx'
 </AccordionItem>
 
 <AccordionItem title="How to start a Waku node?">
-  Follow the README instructions at <a href="https://github.com/waku-org/nwaku-compose">nwaku-compose</a>.
+  Follow the README instructions at <a href="https://docs.waku.org/guides/nwaku/run-node">nwaku-compose</a>.
 </AccordionItem>
 
 

--- a/docs/learn/faq.md
+++ b/docs/learn/faq.md
@@ -33,3 +33,9 @@ import { AccordionItem } from '@site/src/components/mdx'
 <AccordionItem title="What are Rate Limiting Nullifiers (RLN)?">
   <a href="/learn/concepts/protocols#rln-relay">Rate Limiting Nullifier</a> is a zero-knowledge (ZK) protocol enabling spam protection in a decentralized network while preserving privacy. Each message must be accompanied by a ZK proof, which <a href="/learn/concepts/protocols#relay">Relay</a> nodes verify to ensure the publishers do not send more messages than they are allowed. The ZK proof does not leak any private information about message publishers - it only proves they are members of a set of users allowed to publish a certain number of messages per given time frame.
 </AccordionItem>
+
+<AccordionItem title="How to start a Waku node?">
+  Follow the README instructions at <a href="https://github.com/waku-org/nwaku-compose">nwaku-compose</a>.
+</AccordionItem>
+
+


### PR DESCRIPTION
### Description
Adding a new point to refer the nwaku-compose repo. From there, node operators should be able to get the node's FAQ

### Related PR
https://github.com/waku-org/nwaku-compose/pull/120