### PR TITLE
docs: add links to published research papers.md

### DIFF
--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -7,3 +7,9 @@ sidebar_position: 1
 **Research and Studies**: Protocol simulations and theoretical analysis to support the design of Waku protocols. The protocol definitions are on the [Waku RFCs](https://rfc.vac.dev/waku) website.
 
 **Benchmarks**: Results of implementations and engineering-related benchmarks for Waku clients.
+
+Waku also has the following published research papers:
+- [**WAKU-RLN-RELAY: Privacy-Preserving Peer-to-Peer Economic Spam Protection**](https://arxiv.org/abs/2207.00117)
+- [**Message Latency in Waku Relay with Rate Limiting Nullifiers**](https://eprint.iacr.org/2024/1073)
+- [**Waku: A Family of Modular P2P Protocols For Secure & Censorship-Resistant Communication**](https://arxiv.org/abs/2207.00038)
+- [**The Waku Network as Infrastructure for dApps**](https://ieeexplore.ieee.org/document/10646404)


### PR DESCRIPTION
Added links to currently published research papers by Vac/Waku.
Note that the Waku Infrastructure paper does not yet have an open-access version (e.g. arxiv.org). Will update the link once we do.