### PR TITLE
fix: broken links to blog.waku.org

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -48,8 +48,8 @@ Looking for what to build with Waku? Discover a collection of sample ideas and u
 ## Case studies
 
 <div class="case-study-container">
-  <a href="https://blog.waku.org/thegraph-waku-case-study/" target="_blank" rel="noopener noreferrer"><img src="/img/graph-use-case.jpeg" /></a>
-  <a href="https://blog.waku.org/railgun-waku-case-study/" target="_blank" rel="noopener noreferrer"><img src="/img/railgun-use-case.jpeg" /></a>
+  <a href="https://blog.waku.org/2024-05-13-the-graph-case-study/" target="_blank" rel="noopener noreferrer"><img src="/img/graph-use-case.jpeg" /></a>
+  <a href="https://blog.waku.org/2024-04-26-railgun-case-study/" target="_blank" rel="noopener noreferrer"><img src="/img/railgun-use-case.jpeg" /></a>
 </div>
 
 ## Getting started

--- a/docs/guides/js-waku/use-waku-react.md
+++ b/docs/guides/js-waku/use-waku-react.md
@@ -294,5 +294,5 @@ To explore the available Store query options, have a look at the [Retrieve Messa
 :::
 
 :::tip
-You have successfully integrated `@waku/sdk` into a React application using the `@waku/react` package. Have a look at the [web-chat](https://github.com/waku-org/js-waku-examples/tree/master/examples/web-chat) example for a working demo and the [Building a Tic-Tac-Toe Game with Waku](https://blog.waku.org/tictactoe-tutorial) tutorial to learn more.
+You have successfully integrated `@waku/sdk` into a React application using the `@waku/react` package. Have a look at the [web-chat](https://github.com/waku-org/js-waku-examples/tree/master/examples/web-chat) example for a working demo and the [Building a Tic-Tac-Toe Game with Waku](https://blog.waku.org/2024-01-22-tictactoe-tutorial/) tutorial to learn more.
 :::

--- a/docs/learn/waku-network.md
+++ b/docs/learn/waku-network.md
@@ -11,7 +11,7 @@ The Waku Network is a shared p2p messaging network that is open-access, useful f
 4. Services for resource-restricted nodes, including historical message storage and retrieval, filtering, etc.
 
 :::tip
-If you want to learn more about the Waku Network, [The Waku Network: Technical Overview](https://blog.waku.org/2024-waku-network-tech-overview) article provides an in-depth look under the hood.
+If you want to learn more about the Waku Network, [The Waku Network: Technical Overview](https://blog.waku.org/2024-03-26-waku-network-tech-overview/) article provides an in-depth look under the hood.
 :::
 
 ## Why join the Waku network?


### PR DESCRIPTION
All links pointing to blog.waku.org seem to be broken leading to 404.

Updated relevant links to correct working ones.