### PR TITLE
chore: Add which utility as pre-req for fedora build guidance

### DIFF
--- a/docs/guides/nwaku/build-source.md
+++ b/docs/guides/nwaku/build-source.md
@@ -32,7 +32,7 @@ source "$HOME/.cargo/env"
 <TabItem value="fedora" label="Fedora">
 
 ```shell
-sudo dnf install @development-tools git libpq-devel
+sudo dnf install @development-tools git libpq-devel which
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 


### PR DESCRIPTION
[nwaku had a long recorded issue building from source on Fedora Linux.](https://github.com/waku-org/nwaku/issues/2087)
Thanks to @Ivansete-status it is revealed that the only issue is that nimbus build system rely on `which` utility that is not part of the distro out of the box. Installing it fixes the issue, hence mentioning in the build guide.